### PR TITLE
update: 完成lab2,并通过测试

### DIFF
--- a/internal/kvsrv1/client.go
+++ b/internal/kvsrv1/client.go
@@ -1,6 +1,23 @@
 package kvsrv
 
+/*
+网络可能会对RPC请求和/或应答进行重排序、延迟或丢弃。为了应对消息丢失的情况，客户端必须不断重试RPC请求，直到收到服务器的应答。
+对于带有相同版本号的Put请求，重新发送也是安全的，因为服务器会根据版本号来决定是否执行Put操作；如果服务器已经接收并执行了Put请求，
+那么对于重复的Put请求，它会返回rpc.ErrVersion，而不是再次执行Put操作
+
+一个棘手的情况是，如果服务器对客户端重试的RPC请求返回rpc.ErrVersion。在这种情况下，客户端无法确定之前的Put请求是否已经被服务器
+执行：之前的RPC请求可能已经被服务器执行，但服务器的应答消息被网络丢弃，导致客户端只收到对重试请求的rpc.ErrVersion应答。
+或者，也可能是另一个客户端在之前的RPC请求到达服务器之前更新了键值，导致服务器没有执行任何一个客户端的RPC请求，而是对两个请求都返
+回了rpc.ErrVersion。因此，如果客户端收到对重试Put请求的rpc.ErrVersion应答，Clerk.Put函数必须返回rpc.ErrMaybe给应用程序，
+而不是rpc.ErrVersion，因为请求可能已经被执行。
+
+如果Put操作能够保证严格的“至多一次”语义（即不会出现rpc.ErrMaybe错误），对于应用程序开发者来说会更加方便。但要实现这一点，需要在
+务器端为每个客户端维护状态，这比较困难。
+*/
+
 import (
+	"time"
+
 	"github.com/luomingguo/TinyKV/internal/kvsrv1/rpc"
 	kvtest "github.com/luomingguo/TinyKV/internal/kvtest1"
 	tester "github.com/luomingguo/TinyKV/internal/tester1"
@@ -29,7 +46,25 @@ func MakeClerk(clnt *tester.Clnt, server string) kvtest.IKVClerk {
 // arguments. Additionally, reply must be passed as a pointer.
 func (ck *Clerk) Get(key string) (string, rpc.Tversion, rpc.Err) {
 	// You will have to modify this function.
-	return "", 0, rpc.ErrNoKey
+	args := &rpc.GetArgs{
+		Key: key,
+	}
+
+	for {
+		reply := &rpc.GetReply{}
+		ok := ck.clnt.Call(ck.server, "KVServer.Get", args, reply)
+
+		if ok {
+			// RPC调用成功，检查业务逻辑错误
+			switch reply.Err {
+			case rpc.OK:
+				return reply.Value, reply.Version, rpc.OK
+			case rpc.ErrNoKey:
+				return "", 0, rpc.ErrNoKey
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 // Put updates key with value only if the version in the
@@ -51,5 +86,32 @@ func (ck *Clerk) Get(key string) (string, rpc.Tversion, rpc.Err) {
 // arguments. Additionally, reply must be passed as a pointer.
 func (ck *Clerk) Put(key, value string, version rpc.Tversion) rpc.Err {
 	// You will have to modify this function.
-	return rpc.ErrNoKey
+	args := &rpc.PutArgs{
+		Key:     key,
+		Value:   value,
+		Version: version,
+	}
+
+	firstTry := true
+	for {
+		reply := &rpc.PutReply{}
+		ok := ck.clnt.Call(ck.server, "KVServer.Put", args, reply)
+
+		if ok {
+			switch reply.Err {
+			case rpc.OK, rpc.ErrNoKey:
+				// 操作成功
+				return reply.Err
+
+			case rpc.ErrVersion:
+				if !firstTry {
+					return rpc.ErrMaybe
+				}
+				// 首次调用返回ErrVersion，说明版本确实不匹配
+				return reply.Err
+			}
+		}
+		firstTry = false
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/internal/kvsrv1/lock/lock.go
+++ b/internal/kvsrv1/lock/lock.go
@@ -1,7 +1,21 @@
 package lock
 
+/*
+在许多分布式应用中，运行在不同机器上的客户端会使用键值存储服务来协调各自的操作。例如，ZooKeeper 和 etcd
+允许客户端使用分布式锁进行协调，这类似于 Go 程序中线程使用互斥锁（例如 sync.Mutex）进行同步的方式。ZooKeeper
+和 etcd 通过条件写入来实现这种分布式锁。
+如果持有锁的客户端崩溃，则该锁将永远不会被释放。在更复杂的分布式锁设计中，客户端会为锁设置一个租期。
+*/
 import (
+	"time"
+
+	"github.com/luomingguo/TinyKV/internal/kvsrv1/rpc"
 	kvtest "github.com/luomingguo/TinyKV/internal/kvtest1"
+)
+
+const (
+	LockedVal   string = "0"
+	UnlockedVal string = "1"
 )
 
 type Lock struct {
@@ -11,6 +25,7 @@ type Lock struct {
 	// MakeLock().
 	ck kvtest.IKVClerk
 	// You may add code here
+	name string
 }
 
 // The tester calls MakeLock() and passes in a k/v clerk; your code can
@@ -19,15 +34,62 @@ type Lock struct {
 // Use l as the key to store the "lock state" (you would have to decide
 // precisely what the lock state is).
 func MakeLock(ck kvtest.IKVClerk, l string) *Lock {
-	lk := &Lock{ck: ck}
+	lk := &Lock{ck: ck, name: l}
 	// You may add code here
 	return lk
 }
 
 func (lk *Lock) Acquire() {
 	// Your code here
+	//
+	for {
+		var wantVerion rpc.Tversion
+		val, ver, err := lk.ck.Get(lk.name)
+		switch err {
+		case rpc.OK:
+			if val == LockedVal {
+				goto redo
+			}
+			wantVerion = ver
+		case rpc.ErrNoKey:
+			wantVerion = 0
+		default:
+			goto redo
+		}
+		// 返回ErrMaybe
+		err = lk.ck.Put(lk.name, LockedVal, wantVerion)
+		switch err {
+		case rpc.OK:
+			return
+		case rpc.ErrMaybe:
+			val2, ver2, err2 := lk.ck.Get(lk.name)
+			if err2 == rpc.OK && val2 == LockedVal && ver2 == wantVerion+1 {
+				return
+			}
+		}
+	redo:
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 func (lk *Lock) Release() {
 	// Your code here
+	for {
+		val, ver, err := lk.ck.Get(lk.name)
+		if err != rpc.OK || val == UnlockedVal {
+			return
+		}
+
+		err2 := lk.ck.Put(lk.name, UnlockedVal, ver)
+		switch err2 {
+		case rpc.OK:
+			return
+		case rpc.ErrMaybe:
+			val2, _, gerr := lk.ck.Get(lk.name)
+			if gerr == rpc.OK && val2 == UnlockedVal {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/internal/kvsrv1/rpc/rpc.go
+++ b/internal/kvsrv1/rpc/rpc.go
@@ -37,4 +37,3 @@ type GetReply struct {
 	Version Tversion
 	Err     Err
 }
-

--- a/internal/kvsrv1/server.go
+++ b/internal/kvsrv1/server.go
@@ -1,5 +1,18 @@
 package kvsrv
 
+/*
+	构建一个单机KV存储服务器，确保即使在网络故障下，每个Put "至多执行一次"， 并且保证操作的线性一致性。
+	我们将这个键值存储服务器来实现一个分布式锁。后续的将基于此服务器实现复制机制，以应对服务器故障。
+
+	每个客户端通过一个客户端代理（Clerk）与键值存储服务器交互，该代理向服务器发送RPC请求。
+	客户端可以向服务器发送两种RPC请求：Put(key, value, version) 和 Get(key)。
+	版本号记录了该键被写入的次数。Put(key, value, version)只有在Put请求的版本号与服务器中该键的版本号匹配时，
+	才会将值更新到映射表中。如果版本号匹配，服务器还会将该键的版本号加1。如果版本号不匹配，
+	服务器应返回rpc.ErrVersion。客户端可以通过将版本号设置为0来创建一个新键（服务器存储的版本号将为1）。
+	如果Put请求的版本号大于0，但键不存在，服务器应返回rpc.ErrNoKey
+
+*/
+
 import (
 	"log"
 	"sync"
@@ -18,15 +31,19 @@ func DPrintf(format string, a ...interface{}) (n int, err error) {
 	return
 }
 
+type Val struct {
+	Version int64
+	Value   string
+}
+
 type KVServer struct {
 	mu sync.Mutex
-
 	// Your definitions here.
+	container sync.Map
 }
 
 func MakeKVServer() *KVServer {
 	kv := &KVServer{}
-	// Your code here.
 	return kv
 }
 
@@ -34,6 +51,15 @@ func MakeKVServer() *KVServer {
 // exists. Otherwise, Get returns ErrNoKey.
 func (kv *KVServer) Get(args *rpc.GetArgs, reply *rpc.GetReply) {
 	// Your code here.
+	out, ok := kv.container.Load(args.Key)
+	if !ok {
+		reply.Err = rpc.ErrNoKey
+		return
+	}
+	val := out.(Val)
+	reply.Err = rpc.OK
+	reply.Version = rpc.Tversion(val.Version)
+	reply.Value = val.Value
 }
 
 // Update the value for a key if args.Version matches the version of
@@ -42,6 +68,49 @@ func (kv *KVServer) Get(args *rpc.GetArgs, reply *rpc.GetReply) {
 // args.Version is 0, and returns ErrNoKey otherwise.
 func (kv *KVServer) Put(args *rpc.PutArgs, reply *rpc.PutReply) {
 	// Your code here.
+	reply.Err = rpc.OK // 默认 OK
+	cliVerion := int64(args.Version)
+	if cliVerion == 0 {
+		newVal := Val{
+			Version: 1,
+			Value:   args.Value,
+		}
+		// 尝试创建新键，如果键已存在则失败
+		_, loaded := kv.container.LoadOrStore(args.Key, newVal)
+		if loaded {
+			// 键已存在，但客户端版本为0，说明版本不匹配
+			reply.Err = rpc.ErrVersion
+		}
+		return
+	}
+
+	currentVal, exists := kv.container.Load(args.Key)
+	if !exists {
+		// 键不存在但版本号大于0
+		reply.Err = rpc.ErrNoKey
+		return
+	}
+
+	current := currentVal.(Val)
+
+	// 检查版本是否匹配
+	if current.Version != cliVerion {
+		reply.Err = rpc.ErrVersion
+		return
+	}
+
+	// 版本匹配，尝试更新
+	newVal := Val{
+		Version: current.Version + 1,
+		Value:   args.Value,
+	}
+
+	// 使用 CompareAndSwap 确保原子更新
+	if kv.container.CompareAndSwap(args.Key, current, newVal) {
+		return
+	}
+	reply.Err = rpc.ErrVersion
+
 }
 
 // You can ignore Kill() for this lab


### PR DESCRIPTION
C/S实现
>  go test   -v                    
=== RUN   TestReliablePut
One client and reliable Put (reliable network)...
  ... Passed --  time  0.0s #peers 1 #RPCs     5 #Ops    0
--- PASS: TestReliablePut (0.00s)
=== RUN   TestPutConcurrentReliable
Test: many clients racing to put values to the same key (reliable network)...
info: linearizability check timed out, assuming history is ok
  ... Passed --  time 11.0s #peers 1 #RPCs 97983 #Ops 97983
--- PASS: TestPutConcurrentReliable (11.05s)
=== RUN   TestMemPutManyClientsReliable
Test: memory use many put clients (reliable network)...
  ... Passed --  time  5.8s #peers 1 #RPCs 100000 #Ops    0
--- PASS: TestMemPutManyClientsReliable (9.17s)
=== RUN   TestUnreliableNet
One client (unreliable network)...
  ... Passed --  time  9.6s #peers 1 #RPCs   282 #Ops  224
--- PASS: TestUnreliableNet (9.56s)
PASS
ok      github.com/luomingguo/TinyKV/internal/kvsrv1    29.956s

锁的实现
> cd lock && go test
Test: 1 lock clients (reliable network)...
  ... Passed --  time  2.0s #peers 1 #RPCs  1142 #Ops    0
Test: 10 lock clients (reliable network)...
  ... Passed --  time  2.8s #peers 1 #RPCs  1554 #Ops    0
Test: 1 lock clients (unreliable network)...
  ... Passed --  time  2.0s #peers 1 #RPCs    43 #Ops    0
Test: 10 lock clients (unreliable network)...
  ... Passed --  time  4.6s #peers 1 #RPCs   434 #Ops    0
PASS
ok      github.com/luomingguo/TinyKV/internal/kvsrv1/lock       11.925s