### PR TITLE
Lab3 raft 完成选主机制和日志复制保证线性一致性；性能待优化

### DIFF
--- a/internal/raft1/raft.go
+++ b/internal/raft1/raft.go
@@ -6,6 +6,13 @@ package raft
 //
 // Make() creates a new raft peer that implements the raft interface.
 
+/*
+心跳RPC消息不超过10条
+测试程序要求5秒内选主完， 按论文，只有当领导者发送心跳消息的频率远高于每150毫秒一次（例如，每10毫秒一次）时，
+这个范围才有意义。由于测试程序限制了心跳消息的频率，您必须使用大于150到300毫秒的选举超时时间，但也不能太大，
+否则可能无法在5秒内选举出新的领导者
+*/
+
 import (
 	//	"bytes"
 	"math/rand"
@@ -20,6 +27,32 @@ import (
 	tester "github.com/luomingguo/TinyKV/internal/tester1"
 )
 
+type role int
+
+const (
+	Follower role = iota
+	Leader
+	Candidate
+)
+
+func (r role) String() string {
+	switch r {
+	case Follower:
+		return "Follower"
+	case Leader:
+		return "Leader"
+	case Candidate:
+		return "Candidate"
+	default:
+		return "Unknown"
+	}
+}
+
+const (
+	MinElectionTimeout = 300
+	MaxElectionTimeout = 500
+)
+
 // A Go object implementing a single Raft peer.
 type Raft struct {
 	mu        sync.Mutex          // Lock to protect shared access to this peer's state
@@ -31,17 +64,20 @@ type Raft struct {
 	// Your data here (3A, 3B, 3C).
 	// Look at the paper's Figure 2 for a description of what
 	// state a Raft server must maintain.
-
+	currentTerm   int
+	votedFor      int // 当前任期把票给谁了
+	role          role
+	lastHeartBeat time.Time
 }
 
 // return currentTerm and whether this server
 // believes it is the leader.
 func (rf *Raft) GetState() (int, bool) {
 
-	var term int
-	var isleader bool
 	// Your code here (3A).
-	return term, isleader
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	return rf.currentTerm, rf.role == Leader
 }
 
 // save Raft's persistent state to stable storage,
@@ -102,17 +138,47 @@ func (rf *Raft) Snapshot(index int, snapshot []byte) {
 // field names must start with capital letters!
 type RequestVoteArgs struct {
 	// Your data here (3A, 3B).
+	Term        int
+	CandidateId int
 }
 
 // example RequestVote RPC reply structure.
 // field names must start with capital letters!
 type RequestVoteReply struct {
 	// Your data here (3A).
+	Term        int
+	VoteGranted bool // 是否接受选举
 }
 
 // example RequestVote RPC handler.
 func (rf *Raft) RequestVote(args *RequestVoteArgs, reply *RequestVoteReply) {
 	// Your code here (3A, 3B).
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	// 比自己小的则丢弃
+	if args.Term == rf.currentTerm {
+		switch rf.role {
+		case Candidate:
+			reply.VoteGranted = false
+		case Follower:
+			rf.votedFor = args.CandidateId
+			reply.VoteGranted = true
+		case Leader:
+			reply.VoteGranted = false
+			rf.votedFor = -1
+		default:
+			DPrintf("args.Term is Invalid param, %d", args.Term)
+		}
+	} else if args.Term < rf.currentTerm {
+		reply.VoteGranted = false
+	} else {
+		// 如果收到更大的 term，更新自己为 Follower
+		rf.currentTerm = args.Term
+		rf.role = Follower
+		reply.VoteGranted = true
+		rf.votedFor = args.CandidateId
+	}
+	reply.Term = rf.currentTerm
 }
 
 // example code to send a RequestVote RPC to a server.
@@ -190,15 +256,72 @@ func (rf *Raft) killed() bool {
 
 func (rf *Raft) ticker() {
 	for rf.killed() == false {
-
 		// Your code here (3A)
 		// Check if a leader election should be started.
-
+		timeout := time.Duration(MinElectionTimeout+rand.Intn(MaxElectionTimeout-MinElectionTimeout)) * time.Millisecond
+		rf.mu.Lock()
+		if time.Since(rf.lastHeartBeat) >= timeout && rf.role != Leader {
+			rf.doElection()
+		} else {
+			rf.mu.Unlock()
+		}
 		// pause for a random amount of time between 50 and 350
 		// milliseconds.
 		ms := 50 + (rand.Int63() % 300)
 		time.Sleep(time.Duration(ms) * time.Millisecond)
 	}
+}
+
+func (rf *Raft) doElection() {
+
+	rf.currentTerm++
+	rf.role = Candidate
+	rf.votedFor = rf.me
+	args := &RequestVoteArgs{
+		Term:        rf.currentTerm,
+		CandidateId: rf.me,
+	}
+	rf.mu.Unlock() // rpc请求不要占用锁
+
+	voteGrantedCnt := 1 // 先给自己投一篇
+
+	var wg sync.WaitGroup
+	// TODO 这里不支持成员管理了
+	for idx, _ := range rf.peers {
+		if idx == rf.me {
+			continue
+		}
+		wg.Add(1)
+
+		go func(server int) {
+			defer wg.Done()
+			reply := &RequestVoteReply{}
+			ok := rf.sendRequestVote(idx, args, reply)
+			rf.mu.Lock()
+			defer rf.mu.Unlock()
+			if !ok {
+				return
+			}
+			if reply.Term < rf.currentTerm {
+				return
+			} else if reply.Term > rf.currentTerm {
+				rf.currentTerm = reply.Term
+				rf.role = Follower
+				rf.votedFor = -1
+				return
+			}
+			if rf.role == Candidate && reply.VoteGranted {
+				voteGrantedCnt++
+				// 中断如果放在循环后面，需要等待所有节点回复或者失败，
+				if voteGrantedCnt > len(rf.peers)/2 {
+					rf.role = Leader
+					rf.lastHeartBeat = time.Now() // !!!! 重置选举计时器，不然会一直选举
+					// TODO发送心跳
+				}
+			}
+		}(idx)
+	}
+	wg.Wait()
 }
 
 // the service or tester wants to create a Raft server. the ports
@@ -218,6 +341,10 @@ func Make(peers []*labrpc.ClientEnd, me int,
 	rf.me = me
 
 	// Your initialization code here (3A, 3B, 3C).
+	rf.currentTerm = -1
+	rf.votedFor = -1
+	rf.role = Follower
+	rf.lastHeartBeat = time.Now()
 
 	// initialize from state persisted before a crash
 	rf.readPersist(persister.ReadRaftState())

--- a/internal/raft1/raft.go
+++ b/internal/raft1/raft.go
@@ -167,6 +167,8 @@ func (rf *Raft) RequestVote(args *RequestVoteArgs, reply *RequestVoteReply) {
 			reply.VoteGranted = false
 			rf.votedFor = -1
 		default:
+			// 不应该出现，记录日志
+			rf.role = Follower // 容错: 退回 Follower
 			DPrintf("args.Term is Invalid param, %d", args.Term)
 		}
 	} else if args.Term < rf.currentTerm {
@@ -276,52 +278,83 @@ func (rf *Raft) doElection() {
 
 	rf.currentTerm++
 	rf.role = Candidate
+	rf.lastHeartBeat = time.Now() // !!!! 重置选举计时器，不然会一直选举
 	rf.votedFor = rf.me
 	args := &RequestVoteArgs{
 		Term:        rf.currentTerm,
 		CandidateId: rf.me,
 	}
+	peerNum := len(rf.peers)
+	currentTerm := rf.currentTerm
 	rf.mu.Unlock() // rpc请求不要占用锁
 
-	voteGrantedCnt := 1 // 先给自己投一篇
+	majority := peerNum/2 + 1
+	voteChan := make(chan bool, peerNum)
+	termChan := make(chan int, peerNum)
 
-	var wg sync.WaitGroup
+	voteGrantedCnt := 1 // 先给自己投一篇
+	numRsp := 1         // 请求处理，加上自身
 	// TODO 这里不支持成员管理了
-	for idx, _ := range rf.peers {
+	for idx := 0; idx < peerNum; idx++ {
 		if idx == rf.me {
 			continue
 		}
-		wg.Add(1)
 
 		go func(server int) {
-			defer wg.Done()
 			reply := &RequestVoteReply{}
 			ok := rf.sendRequestVote(idx, args, reply)
+			if !ok {
+				voteChan <- false
+				return
+			}
 			rf.mu.Lock()
 			defer rf.mu.Unlock()
-			if !ok {
-				return
-			}
 			if reply.Term < rf.currentTerm {
+				// 忽略过期的响应
+				voteChan <- false
 				return
 			} else if reply.Term > rf.currentTerm {
-				rf.currentTerm = reply.Term
-				rf.role = Follower
-				rf.votedFor = -1
+				termChan <- reply.Term
 				return
 			}
-			if rf.role == Candidate && reply.VoteGranted {
-				voteGrantedCnt++
-				// 中断如果放在循环后面，需要等待所有节点回复或者失败，
-				if voteGrantedCnt > len(rf.peers)/2 {
-					rf.role = Leader
-					rf.lastHeartBeat = time.Now() // !!!! 重置选举计时器，不然会一直选举
-					// TODO发送心跳
-				}
+			if reply.VoteGranted {
+				voteChan <- true
+			} else {
+				voteChan <- false
 			}
 		}(idx)
 	}
-	wg.Wait()
+
+	for voteGrantedCnt < majority && numRsp < peerNum {
+		select {
+		case vote := <-voteChan:
+			numRsp++
+			if !vote {
+				continue
+			}
+			voteGrantedCnt++
+			// 中断如果放在循环后面，需要等待所有节点回复或者失败，
+			if voteGrantedCnt > len(rf.peers)/2 {
+				rf.mu.Lock()
+				// 再次检查状态，确保没有被其他goroutine改变
+				if rf.role == Candidate && rf.currentTerm == currentTerm {
+					rf.role = Leader
+					rf.lastHeartBeat = time.Now()
+					// TODO发送心跳
+				}
+				rf.mu.Unlock()
+			}
+		case higherTerm := <-termChan:
+			numRsp++
+			rf.mu.Lock()
+			if higherTerm > rf.currentTerm {
+				rf.currentTerm = higherTerm
+				rf.role = Follower
+				rf.votedFor = -1
+			}
+			rf.mu.Unlock()
+		}
+	}
 }
 
 // the service or tester wants to create a Raft server. the ports
@@ -341,7 +374,7 @@ func Make(peers []*labrpc.ClientEnd, me int,
 	rf.me = me
 
 	// Your initialization code here (3A, 3B, 3C).
-	rf.currentTerm = -1
+	rf.currentTerm = 1
 	rf.votedFor = -1
 	rf.role = Follower
 	rf.lastHeartBeat = time.Now()

--- a/internal/raft1/raft.go
+++ b/internal/raft1/raft.go
@@ -15,9 +15,11 @@ package raft
 
 import (
 	//	"bytes"
+
 	"math/rand"
 	"sync"
 	"sync/atomic"
+
 	"time"
 
 	"github.com/luomingguo/TinyKV/internal/labrpc"
@@ -49,8 +51,11 @@ func (r role) String() string {
 }
 
 const (
-	MinElectionTimeout = 300
-	MaxElectionTimeout = 500
+	// Raft use random election timeout, in general (150ms~300ms), but we use more bigger (300~500ms)
+	MinElectionTimeout = 600
+	MaxElectionTimeout = 900
+
+	HeartBeatTimeout = 200
 )
 
 // A Go object implementing a single Raft peer.
@@ -60,21 +65,32 @@ type Raft struct {
 	persister *tester.Persister   // Object to hold this peer's persisted state
 	me        int                 // this peer's index into peers[]
 	dead      int32               // set by Kill()
-
-	// Your data here (3A, 3B, 3C).
-	// Look at the paper's Figure 2 for a description of what
+	applyCh   chan raftapi.ApplyMsg
 	// state a Raft server must maintain.
-	currentTerm   int
-	votedFor      int // 当前任期把票给谁了
+	currentTerm int // latest term server has seen(initialized to 0 on first boot, increases monotonically)
+	votedFor    int // candidateId that received vote in current term(or -1 if none)
+	// log entries; each entry contains command for state machine, and term when entry was by leader
+	logs []Entry
+
 	role          role
 	lastHeartBeat time.Time
+
+	// index of highest log entry applied to state machine (initialized to 0, increases monotonically)
+	lastApplied int64
+	// index of highest log entry known to be committed (initialized to 0, increases monotonically)
+	commitIndex int64
+
+	// leader 独有
+	// for each server, index of the next log entry to send to that server(initialized to leader last log index + 1)
+	nextIndex []int64
+	// for each server, index of highest log entry known to be replicated on server (initialized to 0, increase monotonically)
+	matchIndex []int64
 }
 
 // return currentTerm and whether this server
 // believes it is the leader.
 func (rf *Raft) GetState() (int, bool) {
 
-	// Your code here (3A).
 	rf.mu.Lock()
 	defer rf.mu.Unlock()
 	return rf.currentTerm, rf.role == Leader
@@ -134,53 +150,184 @@ func (rf *Raft) Snapshot(index int, snapshot []byte) {
 
 }
 
-// example RequestVote RPC arguments structure.
-// field names must start with capital letters!
+// RequestVote RPC arguments structure.
 type RequestVoteArgs struct {
-	// Your data here (3A, 3B).
-	Term        int
-	CandidateId int
+	Term         int   // candidate’s term
+	LastLogIndex int64 // index of candidate’s last log entry
+	LastLogTerm  int   // term of candidate's last log entry
+	CandidateId  int   // candidate requesting vote
 }
 
-// example RequestVote RPC reply structure.
-// field names must start with capital letters!
+// RequestVote RPC reply structure.
 type RequestVoteReply struct {
-	// Your data here (3A).
-	Term        int
-	VoteGranted bool // 是否接受选举
+	Term        int  // currentTerm, for candidate to update itself
+	VoteGranted bool // true means candidate received vote
 }
 
-// example RequestVote RPC handler.
+// RequestVote RPC handler.
 func (rf *Raft) RequestVote(args *RequestVoteArgs, reply *RequestVoteReply) {
-	// Your code here (3A, 3B).
+	// 1. Reply false if the peer has a more up-to-date term & logIndex
+	// 2. if voteFor is null or candidateId, and candidate's log is at least as up-to-date as receiver's log, grant vote
+
 	rf.mu.Lock()
 	defer rf.mu.Unlock()
-	// 比自己小的则丢弃
-	if args.Term == rf.currentTerm {
-		switch rf.role {
-		case Candidate:
-			reply.VoteGranted = false
-		case Follower:
-			rf.votedFor = args.CandidateId
-			reply.VoteGranted = true
-		case Leader:
-			reply.VoteGranted = false
-			rf.votedFor = -1
-		default:
-			// 不应该出现，记录日志
-			rf.role = Follower // 容错: 退回 Follower
-			DPrintf("args.Term is Invalid param, %d", args.Term)
-		}
-	} else if args.Term < rf.currentTerm {
+
+	// DPrintf("%d[Candidate]->%d[%s] RequestVote args = [Term: %d, LastLogIndex=%d, LastLogTerm=%d], term = %d, votefor=%d, commitIndex = %d, lastApplied = %d", args.CandidateId, rf.me, rf.role.String(), args.Term, args.LastLogIndex, args.LastLogTerm, rf.currentTerm, rf.votedFor, rf.commitIndex, rf.lastApplied)
+
+	lastEntry := rf.logs[len(rf.logs)-1]
+	if args.LastLogTerm < lastEntry.Term {
 		reply.VoteGranted = false
-	} else {
+		reply.Term = rf.currentTerm
+		// DPrintf("%d[Candidate]<-%d[%s] RequestVote reply = [Term: %d,  Successful: %v], term = %d, votefor=%d", args.CandidateId, rf.me, rf.role.String(), reply.Term, reply.VoteGranted, rf.currentTerm, rf.votedFor)
+		return
+	} else if args.LastLogTerm > lastEntry.Term {
 		// 如果收到更大的 term，更新自己为 Follower
+		goto receiveCandidate
+	}
+
+	if args.LastLogIndex < int64(len(rf.logs)-1) {
+		reply.VoteGranted = false
+		reply.Term = rf.currentTerm
+		// DPrintf("%d[Candidate]<-%d[%s] RequestVote reply = [Term: %d,  Successful: %v], term = %d, votefor=%d", args.CandidateId, rf.me, rf.role.String(), reply.Term, reply.VoteGranted, rf.currentTerm, rf.votedFor)
+		return
+	} else if args.LastLogIndex > int64(len(rf.logs)-1) {
+		goto receiveCandidate
+	}
+	if args.Term < rf.currentTerm {
+		reply.VoteGranted = false
+		reply.Term = rf.currentTerm
+
+	} else if args.Term > rf.currentTerm {
+		goto receiveCandidate
+	}
+	if rf.votedFor == -1 || rf.votedFor == args.CandidateId {
+		goto receiveCandidate
+	} else {
+		reply.VoteGranted = false
+		reply.Term = rf.currentTerm
+		// DPrintf("%d[Candidate]<-%d[%s] RequestVote reply = [Term: %d,  Successful: %v], term = %d, votefor=%d", args.CandidateId, rf.me, rf.role.String(), reply.Term, reply.VoteGranted, rf.currentTerm, rf.votedFor)
+		return
+	}
+
+receiveCandidate:
+	rf.currentTerm = args.Term
+	rf.role = Follower
+	reply.VoteGranted = true
+	rf.votedFor = args.CandidateId
+	reply.Term = rf.currentTerm
+	// DPrintf("%d[Candidate]<-%d[%s] RequestVote reply = [Term: %d,  Successful: %v], term = %d, votefor=%d", args.CandidateId, rf.me, rf.role.String(), reply.Term, reply.VoteGranted, rf.currentTerm, rf.votedFor)
+}
+
+type Entry struct {
+	Command any
+	Term    int // first index is 1
+}
+
+// AppendEntriesArgs RPC arguments structure.
+type AppendEntriesArgs struct {
+	Term         int     // leader's term
+	LeaderId     int     // for redirect to Leader for clients
+	PrevLogIndex int64   // index of log entry immediately preceding new ones
+	PrevLogTerm  int     // term of PrevLogIndex entry
+	Entries      []Entry // log entries to store (empty for heartbeat)
+	LeaderCommit int64   // Leader's commit index
+}
+
+// AppendEntriesReply
+type AppendEntriesReply struct {
+	Term    int  // currentTerm, for leader to update itself
+	Success bool // true if follower contained entry matching prevLogIndex and prevLogTerm
+}
+
+func (rf *Raft) AppendEntries(args *AppendEntriesArgs, reply *AppendEntriesReply) {
+	// 1. Reply false if term < currentTerm
+	// 2. Reply false if log doesn't contain an entry at prevLogIndex whose term matches prevLogTerm
+	// 3. If an existing entry conflicts with new one (same index but different terms), delete the existing entry
+	// 		and all that follow it
+	// 4. Append any new entries not already in the log
+	// 5. if leaderCommit > commitIndex, set commitIndex = min(leaderCommit, index of last new entry)
+
+	// for follower: If last log index ≥ nextIndex, then send AppendEntries RPC with log entries starting at nextIndex
+	//	 if successful: update nextIndex and matchIndex for follower
+	//	 if AppendEntries fails bcs of log inconsistency: decrement nextIndex and retry
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	reply.Term = rf.currentTerm
+	reply.Success = false
+
+	// if len(args.Entries) == 0 {
+	// 	DPrintf("%d[%s]->%d[%s] HeartBeat args = [Term: %d, LeaderCommit=%d ], term = %d commitIndex = %d, lastApplied = %d", args.LeaderId, Leader.String(), rf.me, rf.role.String(), args.Term, args.LeaderCommit, rf.currentTerm, rf.commitIndex, rf.lastApplied)
+	// } else {
+	// 	DPrintf("%d[%s]->%d[%s] AppendEntries args = [Term: %d, PrevlogIndex: %d,  PrevLogTerm: %d, len(Entry)=%d, leaderCommit=%d], term = %d commitIndex = %d, lastApplied = %d", args.LeaderId, Leader.String(), rf.me, rf.role.String(), args.Term, args.PrevLogIndex, args.PrevLogTerm, len(args.Entries), args.LeaderCommit, rf.currentTerm, rf.commitIndex, rf.lastApplied)
+	// }
+
+	// 1. Reply false if term < currentTerm
+	if args.Term < rf.currentTerm {
+		// DPrintf("%d[%s]<-%d[%s] AppendEntries reply = [Term: %d, Success=%v ], term = %d commitIndex = %d, lastApplied = %d", args.LeaderId, Leader.String(), rf.me, rf.role.String(), reply.Term, reply.Success, rf.currentTerm, rf.commitIndex, rf.lastApplied)
+		return
+	}
+
+	// 接收到更高或相等的term，转为follower
+	if args.Term >= rf.currentTerm {
 		rf.currentTerm = args.Term
 		rf.role = Follower
-		reply.VoteGranted = true
-		rf.votedFor = args.CandidateId
+		rf.votedFor = -1
+		rf.lastHeartBeat = time.Now()
+		reply.Term = rf.currentTerm
 	}
-	reply.Term = rf.currentTerm
+
+	// 2. Reply false if log doesn't contain an entry at prevLogIndex
+	if args.PrevLogIndex >= int64(len(rf.logs)) {
+		// DPrintf("%d[%s]<-%d[%s] AppendEntries reply = [Term: %d, Success=%v ] - prevLogIndex too high", args.LeaderId, Leader.String(), rf.me, rf.role.String(), reply.Term, reply.Success)
+		return
+	}
+
+	// 3. Reply false if log entry at prevLogIndex has different term
+	if args.PrevLogIndex >= 0 && rf.logs[args.PrevLogIndex].Term != args.PrevLogTerm {
+		// DPrintf("%d[%s]<-%d[%s] AppendEntries reply = [Term: %d, Success=%v ] - term mismatch at prevLogIndex", args.LeaderId, Leader.String(), rf.me, rf.role.String(), reply.Term, reply.Success)
+		return
+	}
+
+	// 4. 如果存在冲突的日志条目，删除它及其后续所有条目
+	insertIndex := args.PrevLogIndex + 1
+	for i := 0; i < len(args.Entries); i++ {
+		entryIndex := insertIndex + int64(i)
+		if entryIndex < int64(len(rf.logs)) {
+			if rf.logs[entryIndex].Term != args.Entries[i].Term {
+				// 发现冲突，删除此位置及后续所有日志
+				rf.logs = rf.logs[:entryIndex]
+				break
+			}
+		} else {
+			break
+		}
+	}
+
+	// 5. 追加新的日志条目
+	for i := 0; i < len(args.Entries); i++ {
+		entryIndex := insertIndex + int64(i)
+		if entryIndex >= int64(len(rf.logs)) {
+			rf.logs = append(rf.logs, args.Entries[i])
+		}
+	}
+
+	reply.Success = true
+
+	// 6. 更新commitIndex
+	if args.LeaderCommit > rf.commitIndex {
+		newCommitIndex := min(args.LeaderCommit, int64(len(rf.logs)-1))
+		if newCommitIndex > rf.commitIndex {
+			rf.commitIndex = newCommitIndex
+			rf.applyCommittedWithGuardLock()
+		}
+	}
+	// if len(args.Entries) == 0 {
+	// 	DPrintf("%d[%s]<-%d[%s] HeartBeat reply = [Term: %d, Success=%v ], term = %d commitIndex = %d, lastApplied = %d", args.LeaderId, Leader.String(), rf.me, rf.role.String(), reply.Term, reply.Success, rf.currentTerm, rf.commitIndex, rf.lastApplied)
+
+	// } else {
+	// 	DPrintf("%d[%s]<-%d[%s] AppendEntries reply = [Term: %d, Success=%v ], term = %d commitIndex = %d, lastApplied = %d", args.LeaderId, Leader.String(), rf.me, rf.role.String(), reply.Term, reply.Success, rf.currentTerm, rf.commitIndex, rf.lastApplied)
+	// }
 }
 
 // example code to send a RequestVote RPC to a server.
@@ -215,6 +362,11 @@ func (rf *Raft) sendRequestVote(server int, args *RequestVoteArgs, reply *Reques
 	return ok
 }
 
+func (rf *Raft) sendAppendEntries(server int, args *AppendEntriesArgs, reply *AppendEntriesReply) bool {
+	ok := rf.peers[server].Call("Raft.AppendEntries", args, reply)
+	return ok
+}
+
 // the service using Raft (e.g. a k/v server) wants to start
 // agreement on the next command to be appended to Raft's log. if this
 // server isn't the leader, returns false. otherwise start the
@@ -228,13 +380,204 @@ func (rf *Raft) sendRequestVote(server int, args *RequestVoteArgs, reply *Reques
 // term. the third return value is true if this server believes it is
 // the leader.
 func (rf *Raft) Start(command interface{}) (int, int, bool) {
-	index := -1
-	term := -1
-	isLeader := true
+	// if command received from client: append entry to local log, respond after entry applied to state machine
+	// if there exist an N such that N > commitIndex, a major of matchIndex[i] >= N, and log[N].term == currentTerm:
+	//   then set commitIndex = N
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	newIndex := len(rf.logs) // for new command
+	if rf.role != Leader {
+		return newIndex, rf.currentTerm, false // 最近提交
+	}
+	currentTerm := rf.currentTerm
+	rf.logs = append(rf.logs, Entry{Command: command, Term: rf.currentTerm})
 
-	// Your code here (3B).
+	// 异步启动日志复制过程
+	go rf.replicateLogEntry(newIndex, currentTerm)
+	return newIndex, rf.currentTerm, true
+}
 
-	return index, term, isLeader
+// 用于收集复制结果
+type replicationResult struct {
+	serverId int
+	success  bool
+	term     int
+}
+
+// replicate to all other server
+func (rf *Raft) replicateLogEntry(logIndex int, term int) {
+	numPeers := len(rf.peers)
+	majority := numPeers/2 + 1
+	// NOTE 如果不能保证每个对端最多回复一个，有死锁风险
+	replicationResultChan := make(chan replicationResult, numPeers)
+
+	for id := 0; id < numPeers; id++ {
+		if id == rf.me {
+			continue
+		}
+		go rf.replicateToServer(id, logIndex, term, replicationResultChan)
+	}
+	successCount := 1 // 包括leader自己
+	responseCount := 1
+	newIdxCommited := false
+	for responseCount < numPeers {
+
+		result := <-replicationResultChan
+		responseCount++
+		if result.term > term { // 粗略确认
+			rf.mu.Lock()
+			if result.term > rf.currentTerm { // 取最大的
+				rf.currentTerm = result.term
+				rf.role = Follower
+				rf.votedFor = -1
+			}
+			rf.mu.Unlock()
+		}
+		if result.success {
+			successCount++
+			rf.mu.Lock()
+			rf.matchIndex[result.serverId] = int64(logIndex)
+			rf.nextIndex[result.serverId] = int64(logIndex + 1)
+			rf.mu.Unlock()
+			if !newIdxCommited && successCount >= majority {
+				rf.commitLogEntry(logIndex) // 必须统一以传入term作为日志的term
+				newIdxCommited = true
+			}
+		}
+	}
+}
+
+func (rf *Raft) replicateToServer(serverId int, newIndex int, term int, resultChan chan<- replicationResult) {
+	for {
+		rf.mu.Lock()
+		if rf.role != Leader || rf.currentTerm != term {
+			rf.mu.Unlock()
+			return
+		}
+
+		nextIdx := rf.nextIndex[serverId]
+		if nextIdx == 0 {
+			nextIdx = 1
+		}
+
+		prevLogIndex := nextIdx - 1
+		var entries []Entry
+
+		// 如果需要发送的日志条目超过了新添加的条目，只发送到新条目为止
+		if int(nextIdx) <= newIndex {
+			endIdx := newIndex + 1
+			if endIdx > len(rf.logs) {
+				endIdx = len(rf.logs)
+			}
+			entries = rf.logs[nextIdx:endIdx]
+		} else {
+			// 已经同步完成
+			rf.mu.Unlock()
+			resultChan <- replicationResult{
+				serverId: serverId,
+				success:  true,
+				term:     term,
+			}
+			return
+		}
+
+		args := &AppendEntriesArgs{
+			Term:         term,
+			LeaderId:     rf.me,
+			PrevLogIndex: prevLogIndex,
+			PrevLogTerm:  0,
+			Entries:      entries,
+			LeaderCommit: rf.commitIndex,
+		}
+
+		if prevLogIndex >= 0 && prevLogIndex < int64(len(rf.logs)) {
+			args.PrevLogTerm = rf.logs[prevLogIndex].Term
+		}
+
+		rf.mu.Unlock()
+
+		reply := &AppendEntriesReply{}
+		ok := rf.sendAppendEntries(serverId, args, reply)
+
+		if !ok {
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+
+		rf.mu.Lock()
+		// 检查term是否过期
+		if reply.Term > rf.currentTerm {
+			rf.currentTerm = reply.Term
+			rf.role = Follower
+			rf.votedFor = -1
+			rf.mu.Unlock()
+			resultChan <- replicationResult{
+				serverId: serverId,
+				success:  false,
+				term:     reply.Term,
+			}
+			return
+		}
+
+		if reply.Success {
+			// 成功，更新nextIndex和matchIndex
+			newNextIndex := prevLogIndex + 1 + int64(len(entries))
+			rf.nextIndex[serverId] = newNextIndex
+			rf.matchIndex[serverId] = newNextIndex - 1
+
+			// 检查是否完成了目标日志的复制
+			if rf.matchIndex[serverId] >= int64(newIndex) {
+				rf.mu.Unlock()
+				resultChan <- replicationResult{
+					serverId: serverId,
+					success:  true,
+					term:     term,
+				}
+				return
+			}
+			rf.mu.Unlock()
+			// 继续发送剩余的日志条目
+			continue
+		} else {
+			// 失败，回退nextIndex
+			if rf.nextIndex[serverId] > 1 {
+				rf.nextIndex[serverId]--
+			}
+			rf.mu.Unlock()
+			// 继续尝试
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+	}
+}
+
+// commitLogEntry 提交指定的日志条目
+func (rf *Raft) commitLogEntry(logIndex int) {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	// 更新commitIndex
+	if int64(logIndex) > rf.commitIndex {
+		rf.commitIndex = int64(logIndex)
+		rf.applyCommittedWithGuardLock()
+	}
+}
+
+// 在newIndex之前的日志都可以apply
+func (rf *Raft) applyCommittedWithGuardLock() {
+
+	for rf.lastApplied < rf.commitIndex {
+		rf.lastApplied++
+		entry := rf.logs[rf.lastApplied]
+		applyMsg := raftapi.ApplyMsg{
+			CommandValid: true,
+			Command:      entry.Command,
+			CommandIndex: int(rf.lastApplied),
+		}
+		rf.mu.Unlock()
+		rf.applyCh <- applyMsg // 避免阻塞死锁
+		rf.mu.Lock()
+	}
 }
 
 // the tester doesn't halt goroutines created by Raft after each test,
@@ -258,12 +601,13 @@ func (rf *Raft) killed() bool {
 
 func (rf *Raft) ticker() {
 	for rf.killed() == false {
-		// Your code here (3A)
+
 		// Check if a leader election should be started.
-		timeout := time.Duration(MinElectionTimeout+rand.Intn(MaxElectionTimeout-MinElectionTimeout)) * time.Millisecond
+		electMs := MinElectionTimeout + (rand.Int63() % (MaxElectionTimeout - MinElectionTimeout))
+		timeout := time.Duration(electMs) * time.Millisecond
 		rf.mu.Lock()
 		if time.Since(rf.lastHeartBeat) >= timeout && rf.role != Leader {
-			rf.doElection()
+			rf.startElectionLocked()
 		} else {
 			rf.mu.Unlock()
 		}
@@ -274,76 +618,79 @@ func (rf *Raft) ticker() {
 	}
 }
 
-func (rf *Raft) doElection() {
-
+// startElectionLocked it has lock locked at the beginning
+func (rf *Raft) startElectionLocked() {
+	/*
+		On conversion to Candidate, start election:
+		- increment currentTerm
+		- Vote for itself
+		- Reset election timer
+		- Send RequestVote RPC to all other servers
+		If vote received from majority: become leader
+		If AppendEntries RPC received from new Leader: covert to folloer
+		If election timeout elapses: start new election
+	*/
 	rf.currentTerm++
 	rf.role = Candidate
-	rf.lastHeartBeat = time.Now() // !!!! 重置选举计时器，不然会一直选举
+	rf.lastHeartBeat = time.Now()
 	rf.votedFor = rf.me
 	args := &RequestVoteArgs{
-		Term:        rf.currentTerm,
-		CandidateId: rf.me,
+		Term:         rf.currentTerm,
+		CandidateId:  rf.me,
+		LastLogTerm:  rf.logs[len(rf.logs)-1].Term,
+		LastLogIndex: int64(len(rf.logs) - 1),
 	}
-	peerNum := len(rf.peers)
 	currentTerm := rf.currentTerm
-	rf.mu.Unlock() // rpc请求不要占用锁
+	rf.mu.Unlock()
 
+	peerNum := len(rf.peers)
 	majority := peerNum/2 + 1
-	voteChan := make(chan bool, peerNum)
-	termChan := make(chan int, peerNum)
+	voteChan := make(chan bool, peerNum-1)
+	termChan := make(chan int, peerNum-1)
 
 	voteGrantedCnt := 1 // 先给自己投一篇
 	numRsp := 1         // 请求处理，加上自身
-	// TODO 这里不支持成员管理了
+	// TODO not yet support member managemant
 	for idx := 0; idx < peerNum; idx++ {
 		if idx == rf.me {
 			continue
 		}
-
-		go func(server int) {
+		go func(server, term int) {
 			reply := &RequestVoteReply{}
-			ok := rf.sendRequestVote(idx, args, reply)
+			ok := rf.sendRequestVote(server, args, reply)
 			if !ok {
 				voteChan <- false
 				return
 			}
-			rf.mu.Lock()
-			defer rf.mu.Unlock()
-			if reply.Term < rf.currentTerm {
-				// 忽略过期的响应
-				voteChan <- false
-				return
-			} else if reply.Term > rf.currentTerm {
-				termChan <- reply.Term
-				return
-			}
 			if reply.VoteGranted {
 				voteChan <- true
-			} else {
-				voteChan <- false
+				return
 			}
-		}(idx)
+			voteChan <- false
+			if reply.Term > term {
+				termChan <- reply.Term
+			}
+		}(idx, currentTerm)
 	}
 
 	for voteGrantedCnt < majority && numRsp < peerNum {
+
 		select {
-		case vote := <-voteChan:
+		case granted := <-voteChan:
 			numRsp++
-			if !vote {
-				continue
-			}
-			voteGrantedCnt++
-			// 中断如果放在循环后面，需要等待所有节点回复或者失败，
-			if voteGrantedCnt > len(rf.peers)/2 {
-				rf.mu.Lock()
-				// 再次检查状态，确保没有被其他goroutine改变
-				if rf.role == Candidate && rf.currentTerm == currentTerm {
-					rf.role = Leader
-					rf.lastHeartBeat = time.Now()
-					// TODO发送心跳
+			if granted {
+				voteGrantedCnt++
+				if voteGrantedCnt >= majority {
+					rf.mu.Lock()
+					defer rf.mu.Unlock()
+					// 再次检查状态，确保没有被其他goroutine改变
+					if rf.role == Candidate && rf.currentTerm == currentTerm {
+						rf.startLeaderWithLockGuard()
+					}
+					return
 				}
-				rf.mu.Unlock()
 			}
+
 		case higherTerm := <-termChan:
 			numRsp++
 			rf.mu.Lock()
@@ -353,8 +700,67 @@ func (rf *Raft) doElection() {
 				rf.votedFor = -1
 			}
 			rf.mu.Unlock()
+			return
 		}
 	}
+}
+
+// 在成为Leader时启动复制循环
+func (rf *Raft) startLeaderWithLockGuard() {
+	rf.role = Leader
+	// 初始化nextIndex和matchIndex
+	for i := range rf.peers {
+		rf.nextIndex[i] = int64(len(rf.logs))
+		rf.matchIndex[i] = 0
+	}
+	rf.matchIndex[rf.me] = int64(len(rf.logs) - 1)
+	term := rf.currentTerm
+	// DPrintf("%d becomes leader at term %d", rf.me, term)
+	// 启动复制循环
+	// go rf.startReplicationLoop(term)
+	// 启动心跳循环
+	go rf.startHeartBeatLoop(term)
+}
+
+func (rf *Raft) startHeartBeatLoop(term int) {
+
+	for {
+		rf.mu.Lock()
+		if term != rf.currentTerm || rf.role != Leader {
+			rf.mu.Unlock()
+			return
+		}
+		rf.lastHeartBeat = time.Now()
+		args := &AppendEntriesArgs{
+			Term:         rf.currentTerm,
+			LeaderId:     rf.me,
+			PrevLogIndex: int64(len(rf.logs) - 1),
+			PrevLogTerm:  rf.logs[len(rf.logs)-1].Term,
+			Entries:      make([]Entry, 0),
+			LeaderCommit: rf.commitIndex,
+		}
+		rf.mu.Unlock()
+		for idx := 0; idx < len(rf.peers); idx++ {
+			if idx == rf.me {
+				continue
+			}
+			go func(server int) {
+				reply := &AppendEntriesReply{}
+				ok := rf.sendAppendEntries(server, args, reply)
+				if ok && reply.Term > args.Term {
+					rf.mu.Lock()
+					if reply.Term > rf.currentTerm {
+						rf.currentTerm = reply.Term
+						rf.role = Follower
+						rf.votedFor = -1
+					}
+					rf.mu.Unlock()
+				}
+			}(idx)
+		}
+		time.Sleep(time.Duration(HeartBeatTimeout) * time.Millisecond)
+	}
+
 }
 
 // the service or tester wants to create a Raft server. the ports
@@ -372,12 +778,26 @@ func Make(peers []*labrpc.ClientEnd, me int,
 	rf.peers = peers
 	rf.persister = persister
 	rf.me = me
-
-	// Your initialization code here (3A, 3B, 3C).
-	rf.currentTerm = 1
+	rf.applyCh = applyCh
+	rf.currentTerm = 0
 	rf.votedFor = -1
 	rf.role = Follower
 	rf.lastHeartBeat = time.Now()
+
+	rf.lastApplied = 0
+	rf.commitIndex = 0
+	rf.logs = []Entry{
+		{
+			Command: nil,
+			Term:    0,
+		},
+	} // dummy log entry, so it is 1st-index
+	rf.nextIndex = make([]int64, len(peers))
+	rf.matchIndex = make([]int64, len(peers))
+	for i := range rf.peers {
+		rf.nextIndex[i] = 1
+		rf.matchIndex[i] = 0
+	}
 
 	// initialize from state persisted before a crash
 	rf.readPersist(persister.ReadRaftState())


### PR DESCRIPTION
mac@Rons-MacBook raft1 % time go test -run 3B 
Test (3B): basic agreement (reliable network)...
  ... Passed --  time  1.3s #peers 3 #RPCs    16 #Ops    0
Test (3B): RPC byte count (reliable network)...
  ... Passed --  time  3.0s #peers 3 #RPCs    48 #Ops    0
Test (3B): test progressive failure of followers (reliable network)...
  ... Passed --  time  5.2s #peers 3 #RPCs    60 #Ops    0
Test (3B): test failure of leaders (reliable network)...
  ... Passed --  time  6.0s #peers 3 #RPCs   110 #Ops    0
Test (3B): agreement after follower reconnects (reliable network)...
  ... Passed --  time  6.6s #peers 3 #RPCs    82 #Ops    0
Test (3B): no agreement if too many followers disconnect (reliable network)...
  ... Passed --  time  4.5s #peers 5 #RPCs   114 #Ops    0
Test (3B): concurrent Start()s (reliable network)...
  ... Passed --  time  1.1s #peers 3 #RPCs    18 #Ops    0
Test (3B): rejoin of partitioned leader (reliable network)...
  ... Passed --  time  5.2s #peers 3 #RPCs    93 #Ops    0
Test (3B): leader backs up quickly over incorrect follower logs (reliable network)...
  ... Passed --  time 31.9s #peers 5 #RPCs  3825 #Ops    0
Test (3B): RPC counts aren't too high (reliable network)...
  ... Passed --  time  2.6s #peers 3 #RPCs    45 #Ops    0
PASS
ok      github.com/luomingguo/TinyKV/internal/raft1     67.830s
go test -run 3B  2.31s user 1.22s system 5% cpu 1:08.89 total

